### PR TITLE
Enable CI and bump Gleam version to 0.20.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,10 @@ jobs:
       - uses: actions/checkout@v2.0.0
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "24.2"
-          elixir-version: "1.13.1"
-          gleam-version: "0.19.0-rc3"
-      - run: gleam test
+          otp-version: false
+          gleam-version: '0.20.0'
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
       - run: gleam format --check src test
+      - run: gleam test


### PR DESCRIPTION
Successful run at https://github.com/michallepicki/javascript/runs/5310382848 (I had temorarily added the branch name to `on push branches` list)