### PR TITLE
Add Promise.race functions

### DIFF
--- a/src/ffi.mjs
+++ b/src/ffi.mjs
@@ -139,6 +139,14 @@ export function all_promises(...promises) {
   }
 }
 
+export function race_promises(...promises) {
+  if (promises.length === 1) {
+    return Promise.race(promises[0]);
+  } else {
+    return Promise.race(promises);
+  }
+}
+
 export function map_new() {
   return new Map();
 }

--- a/src/gleam/javascript/promise.gleam
+++ b/src/gleam/javascript/promise.gleam
@@ -102,3 +102,42 @@ pub fn await_list(xs: List(Promise(a))) -> Promise(List(a)) {
 
 @external(javascript, "../../ffi.mjs", "all_promises")
 fn do_await_list(a: List(Promise(a))) -> Promise(Array(a))
+
+@external(javascript, "../../ffi.mjs", "race_promises")
+pub fn race2(a: Promise(a), b: Promise(a)) -> Promise(a)
+
+@external(javascript, "../../ffi.mjs", "race_promises")
+pub fn race3(a: Promise(a), b: Promise(a), c: Promise(a)) -> Promise(a)
+
+@external(javascript, "../../ffi.mjs", "race_promises")
+pub fn race4(
+  a: Promise(a),
+  b: Promise(a),
+  c: Promise(a),
+  d: Promise(a),
+) -> Promise(a)
+
+@external(javascript, "../../ffi.mjs", "race_promises")
+pub fn race5(
+  a: Promise(a),
+  b: Promise(a),
+  c: Promise(a),
+  d: Promise(a),
+  e: Promise(a),
+) -> Promise(a)
+
+@external(javascript, "../../ffi.mjs", "race_promises")
+pub fn race6(
+  a: Promise(a),
+  b: Promise(a),
+  c: Promise(a),
+  d: Promise(a),
+  e: Promise(a),
+  f: Promise(a),
+) -> Promise(a)
+
+@external(javascript, "../../ffi.mjs", "race_promises")
+pub fn race_list(a: List(Promise(a))) -> Promise(a)
+
+@external(javascript, "../../ffi.mjs", "race_promises")
+pub fn race_array(a: Array(Promise(a))) -> Promise(a)

--- a/test/gleam/javascript/promise_test.gleam
+++ b/test/gleam/javascript/promise_test.gleam
@@ -1,6 +1,7 @@
-import gleam/javascript/promise.{type Promise}
-import gleam/javascript/array
+import gleam/io
 import gleam/javascript.{ObjectType}
+import gleam/javascript/array
+import gleam/javascript/promise.{type Promise}
 
 pub fn new_promise_test() {
   promise.new(fn(resolve) { resolve(1) })
@@ -209,5 +210,90 @@ pub fn await_list_test() {
   ])
   |> promise.tap(fn(x) {
     let assert [1, 3, 4, 6, 10, 13] = x
+  })
+}
+
+fn never_resolving_promise() {
+  promise.new(fn(_) { Nil })
+}
+
+pub fn race2_test() {
+  promise.race2(never_resolving_promise(), promise.resolve(1))
+  |> promise.tap(fn(x) {
+    let assert 1 = x
+  })
+}
+
+pub fn race3_test() {
+  promise.race3(
+    never_resolving_promise(),
+    promise.resolve(1),
+    never_resolving_promise(),
+  )
+  |> promise.tap(fn(x) {
+    let assert 1 = x
+  })
+}
+
+pub fn race4_test() {
+  promise.race4(
+    never_resolving_promise(),
+    never_resolving_promise(),
+    promise.resolve(1),
+    never_resolving_promise(),
+  )
+  |> promise.tap(fn(x) {
+    let assert 1 = x
+  })
+}
+
+pub fn race5_test() {
+  promise.race5(
+    never_resolving_promise(),
+    never_resolving_promise(),
+    promise.resolve(1),
+    never_resolving_promise(),
+    never_resolving_promise(),
+  )
+  |> promise.tap(fn(x) {
+    let assert 1 = x
+  })
+}
+
+pub fn race6_test() {
+  promise.race6(
+    never_resolving_promise(),
+    never_resolving_promise(),
+    promise.resolve(1),
+    never_resolving_promise(),
+    never_resolving_promise(),
+    never_resolving_promise(),
+  )
+  |> promise.tap(fn(x) {
+    let assert 1 = x
+  })
+}
+
+pub fn race_list_test() {
+  promise.race_list([
+    never_resolving_promise(),
+    promise.resolve(1),
+    never_resolving_promise(),
+  ])
+  |> promise.tap(fn(x) {
+    let assert 1 = x
+  })
+}
+
+pub fn race_array_test() {
+  promise.race_array(
+    array.from_list([
+      never_resolving_promise(),
+      promise.resolve(1),
+      never_resolving_promise(),
+    ]),
+  )
+  |> promise.tap(fn(x) {
+    let assert 1 = x
   })
 }


### PR DESCRIPTION
Wasn't 100% sure how to approach the tests, I guess they're just about ok?

Currently if I replace my call to `promise.race2` with `promise.await2` the tests still pass, because the `tap` containing the assertion just never fires. Not entirely sure why it doesn't just hang forever though? I thought the test runner awaits the test case function.. and my test case function should be returning a Promise that never resolves.

Closes #11