### PR TITLE
Renamed `then` to `then_await` to fix conflicts when running in Vite

### DIFF
--- a/src/gleam/javascript/promise.gleam
+++ b/src/gleam/javascript/promise.gleam
@@ -49,7 +49,7 @@ pub fn rescue(a: Promise(value), b: fn(Dynamic) -> value) -> Promise(value)
 ///
 /// This is the equivilent of the `promise.then` JavaScript method.
 ///
-@external(javascript, "../../gleam_javascript_ffi.mjs", "then")
+@external(javascript, "../../gleam_javascript_ffi.mjs", "then_await")
 pub fn await(a: Promise(a), b: fn(a) -> Promise(b)) -> Promise(b)
 
 /// Run a function on the value a promise resolves to, after it has resolved.

--- a/src/gleam_javascript_ffi.mjs
+++ b/src/gleam_javascript_ffi.mjs
@@ -93,7 +93,7 @@ export function resolve(value) {
   return Promise.resolve(PromiseLayer.wrap(value));
 }
 
-export function then(promise, fn) {
+export function then_await(promise, fn) {
   return promise.then((value) => fn(PromiseLayer.unwrap(value)));
 }
 
@@ -127,7 +127,7 @@ export function set_reference(ref, value) {
   return previous;
 }
 
-export function reference_equal(a,b) {
+export function reference_equal(a, b) {
   return a === b
 }
 


### PR DESCRIPTION
Importing gleam_javascript in a Vite project causes some conflicts with `promise.then`. I tried to see if it's a problem with Vite, yet I didn't find anything. So an easy fix for this bug would be to rename `then` to something else. `then_await` might be a bit misleading so it could need another name.

I was thinking about if it could be a breaking change, but I don't see `then` exposed so it shouldn't be a problem. Also, it could be a bug in the way that Gleam compiles to Javascript.

Similar result happens in Astro, as they also use Vite. Nothing worked except changing the name of the `then` function.

I am pretty new to the Gleam language, so there are a few things I might not understand, but I wanted to help with this bug for future Vite users who might want to embed Gleam in their projects.