### PR TITLE
add a promise.wait functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add `wait` to `promise` module.
+
 ## v0.12.0 - 2024-08-19
 
 - Fixed a bug where `array.to_list` could produce incorrect results.

--- a/src/gleam/javascript/promise.gleam
+++ b/src/gleam/javascript/promise.gleam
@@ -233,3 +233,9 @@ pub fn race_list(a: List(Promise(a))) -> Promise(a)
 
 @external(javascript, "../../gleam_javascript_ffi.mjs", "race_promises")
 pub fn race_array(a: Array(Promise(a))) -> Promise(a)
+
+/// Create a promise that will resolve after a delay.
+/// The delay is specified in milliseconds
+///
+@external(javascript, "../../gleam_javascript_ffi.mjs", "wait")
+pub fn wait(delay: Int) -> Promise(Nil)

--- a/src/gleam_javascript_ffi.mjs
+++ b/src/gleam_javascript_ffi.mjs
@@ -107,6 +107,12 @@ export function rescue(promise, fn) {
   return promise.catch((error) => fn(error));
 }
 
+export function wait(delay) {
+  return new Promise((resolve) => {
+    globalThis.setTimeout(resolve, delay);
+  })
+}
+
 export function all_promises(...promises) {
   if (promises.length === 1) {
     return Promise.all(promises[0]);

--- a/test/gleam/javascript/promise_test.gleam
+++ b/test/gleam/javascript/promise_test.gleam
@@ -296,3 +296,9 @@ pub fn race_array_test() {
     let assert 1 = x
   })
 }
+
+pub fn promise_wait_test() {
+  promise.tap(promise.wait(100), fn(x) {
+    let Nil = x
+  })
+}


### PR DESCRIPTION
I keep recreating this. To build a timeout function requires something like plinth or writing your own ffi. Both of these approaches are quite heavy handed. because setTimeout is on globalThis and part of the JavaScript spec I don't foresee any maintenance burden across platforms like deno etc.