### PR TITLE
Add `promise.settled_*` and `promise.any_*` functions

### DIFF
--- a/src/gleam/javascript/promise.gleam
+++ b/src/gleam/javascript/promise.gleam
@@ -21,6 +21,23 @@ import gleam/javascript/array.{type Array}
 ///
 pub type Promise(value)
 
+/// `Settled` represents the state of a `Promise`, after it has run and settled.
+/// A promise can be either successful, or failing. In case the promise
+/// succeeded, `Fulfilled` is returned, while `Rejected` is returned when the
+/// promise failed.
+///
+/// It's impossible to read the state of a promise per se, except when using
+/// [`settled_array`](#settled_array) or [`settled_list`](#settled_list).
+///
+/// Further information can be found
+/// [on MDN, on `Promise.allSettled`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled)
+/// documentation.
+///
+pub type Settled(value) {
+  Fulfilled(value)
+  Rejected(Dynamic)
+}
+
 /// Create a new promise from a callback function. The callback function itself
 /// takes a second function as an argument, and when that second function is
 /// called with a value then the promise resolves with that value.
@@ -138,6 +155,30 @@ pub fn await_list(xs: List(Promise(a))) -> Promise(List(a)) {
   |> do_await_list
   |> map(array.to_list)
 }
+
+/// Chain an asynchronous operation onto a list of promises, so it runs
+/// after all promises have ended, whether they succeeded or not.
+///
+/// This is the equivilent of [`Promise.allSettled`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled)
+/// JavaScript method.
+///
+@external(javascript, "../../gleam_javascript_ffi.mjs", "settled_await")
+pub fn settled_array(xs: Array(Promise(a))) -> Promise(Array(Settled(a)))
+
+/// Chain an asynchronous operation onto a list of promises, so it runs
+/// after all promises have ended, whether they succeeded or not.
+///
+/// This is the equivilent of [`Promise.allSettled`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled)
+/// JavaScript method.
+///
+pub fn settled_list(xs: List(Promise(a))) -> Promise(List(Settled(a))) {
+  xs
+  |> do_settled_list
+  |> map(array.to_list)
+}
+
+@external(javascript, "../../gleam_javascript_ffi.mjs", "settled_await")
+fn do_settled_list(a: List(Promise(a))) -> Promise(Array(Settled(a)))
 
 @external(javascript, "../../gleam_javascript_ffi.mjs", "all_promises")
 fn do_await_list(a: List(Promise(a))) -> Promise(Array(a))

--- a/src/gleam/javascript/promise.gleam
+++ b/src/gleam/javascript/promise.gleam
@@ -180,6 +180,28 @@ pub fn settled_list(xs: List(Promise(a))) -> Promise(List(Settled(a))) {
 @external(javascript, "../../gleam_javascript_ffi.mjs", "settled_await")
 fn do_settled_list(a: List(Promise(a))) -> Promise(Array(Settled(a)))
 
+/// Chain an asynchronous operation onto a list of promises, so it runs
+/// after one promise have successfully ended. `any_array` throws an error
+/// when all promises have failed, or when there's no promises at all in the
+/// array.
+///
+/// This is the equivilent of [`Promise.any`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/any)
+/// JavaScript method.
+///
+@external(javascript, "../../gleam_javascript_ffi.mjs", "any_await")
+pub fn any_array(xs: Array(Promise(a))) -> Promise(a)
+
+/// Chain an asynchronous operation onto a list of promises, so it runs
+/// after one promise have successfully ended. `any_list` throws an error
+/// when all promises have failed, or when there's no promises at all in the
+/// list.
+///
+/// This is the equivilent of [`Promise.any`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/any)
+/// JavaScript method.
+///
+@external(javascript, "../../gleam_javascript_ffi.mjs", "any_await")
+pub fn any_list(xs: List(Promise(a))) -> Promise(a)
+
 @external(javascript, "../../gleam_javascript_ffi.mjs", "all_promises")
 fn do_await_list(a: List(Promise(a))) -> Promise(Array(a))
 

--- a/src/gleam_javascript_ffi.mjs
+++ b/src/gleam_javascript_ffi.mjs
@@ -145,3 +145,7 @@ export async function settled_await(promises) {
     }
   });
 }
+
+export function any_await(promises) {
+  return Promise.any(promises);
+}

--- a/src/gleam_javascript_ffi.mjs
+++ b/src/gleam_javascript_ffi.mjs
@@ -1,4 +1,6 @@
 import { Ok, Error } from "./gleam.mjs";
+import * as $promises from "./gleam/javascript/promise.mjs";
+
 export function toArray(list) {
   return list.toArray();
 }
@@ -130,4 +132,16 @@ export function map_get(map, key) {
 
 export function map_size(map) {
   return map.size;
+}
+
+export async function settled_await(promises) {
+  const result = await Promise.allSettled(promises);
+  return result.map((res) => {
+    switch (res.status) {
+      case "fulfilled":
+        return new $promises.Fulfilled(res.value);
+      case "rejected":
+        return new $promises.Rejected(res.reason);
+    }
+  });
 }

--- a/test/gleam/javascript/promise_test.gleam
+++ b/test/gleam/javascript/promise_test.gleam
@@ -211,3 +211,42 @@ pub fn promise_wait_test() {
     let Nil = x
   })
 }
+
+pub fn settled_array_test() {
+  promise.settled_array(
+    array.from_list([
+      promise.resolve(100),
+      promise.resolve(1)
+        |> promise.map(fn(_) {
+          let assert 1 = 2
+        }),
+      promise.resolve(200),
+    ]),
+  )
+  |> promise.tap(fn(x) {
+    let x = array.to_list(x)
+    let assert [
+      promise.Fulfilled(100),
+      promise.Rejected(_),
+      promise.Fulfilled(200),
+    ] = x
+  })
+}
+
+pub fn settled_list_test() {
+  promise.settled_list([
+    promise.resolve(100),
+    promise.resolve(1)
+      |> promise.map(fn(_) {
+        let assert 1 = 2
+      }),
+    promise.resolve(200),
+  ])
+  |> promise.tap(fn(x) {
+    let assert [
+      promise.Fulfilled(100),
+      promise.Rejected(_),
+      promise.Fulfilled(200),
+    ] = x
+  })
+}

--- a/test/gleam/javascript/promise_test.gleam
+++ b/test/gleam/javascript/promise_test.gleam
@@ -1,3 +1,4 @@
+import gleam/dynamic/decode
 import gleam/javascript/array
 import gleam/javascript/promise.{type Promise}
 import helper.{ObjectType}
@@ -248,5 +249,67 @@ pub fn settled_list_test() {
       promise.Rejected(_),
       promise.Fulfilled(200),
     ] = x
+  })
+}
+
+pub fn any_array_test() {
+  promise.any_array(
+    array.from_list([
+      never_resolving_promise(),
+      promise.resolve(1),
+      never_resolving_promise(),
+      promise.wait(100) |> promise.map(fn(_) { 2 }),
+    ]),
+  )
+  |> promise.tap(fn(x) {
+    let assert 1 = x
+  })
+}
+
+pub fn any_array_fail_test() {
+  promise.any_array(
+    array.from_list([
+      promise.resolve(1)
+      |> promise.map(fn(_) {
+        let assert 1 = 2
+      }),
+    ]),
+  )
+  |> promise.rescue(fn(dyn) {
+    let content = decode.run(dyn, decode.at(["name"], decode.string))
+    let assert Ok("AggregateError") = content
+    10
+  })
+  |> promise.tap(fn(x) {
+    let assert 10 = x
+  })
+}
+
+pub fn any_list_test() {
+  promise.any_list([
+    never_resolving_promise(),
+    promise.resolve(1),
+    never_resolving_promise(),
+    promise.wait(100) |> promise.map(fn(_) { 2 }),
+  ])
+  |> promise.tap(fn(x) {
+    let assert 1 = x
+  })
+}
+
+pub fn any_list_fail_test() {
+  promise.any_list([
+    promise.resolve(1)
+    |> promise.map(fn(_) {
+      let assert 1 = 2
+    }),
+  ])
+  |> promise.rescue(fn(dyn) {
+    let content = decode.run(dyn, decode.at(["name"], decode.string))
+    let assert Ok("AggregateError") = content
+    10
+  })
+  |> promise.tap(fn(x) {
+    let assert 10 = x
   })
 }


### PR DESCRIPTION
Hi!

`Promise.allSettled` and `Promise.any` are common to use in JavaScript, and I have to FFI them in projects, so I suggest to add them to `gleam_javascript`!

Tell me if you agree, I tried a gleamesque approach, but I'm not sure about `Settled` type. 🙂